### PR TITLE
mi439: Drop pine from assert devices

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -10,7 +10,7 @@ include device/xiaomi/sdm439-common/BoardConfigCommon.mk
 DEVICE_PATH := device/xiaomi/mi439
 
 # Asserts
-TARGET_OTA_ASSERT_DEVICE := pine,olive,olivelite,olivewood,olives,mi439,Mi439
+TARGET_OTA_ASSERT_DEVICE := olive,olivelite,olivewood,olives,mi439,Mi439
 
 # Display
 TARGET_SCREEN_DENSITY := 320


### PR DESCRIPTION
• As required by PixelExperience CoC (Code of Conduct), 2gb ram devices are not allowed. So drop pine, pine users can still flash it by adding pine in assert line while flashing.

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed
